### PR TITLE
eliminación de contraseña de email de empresa

### DIFF
--- a/pages/contact.php
+++ b/pages/contact.php
@@ -43,7 +43,7 @@
                 $mail->Host       = 'smtp.office365.com';               //Set the SMTP server to send through
                 $mail->SMTPAuth   = true;                               //Enable SMTP authentication
                 $mail->Username   = 'mamba_sneakers@outlook.com';       //SMTP username
-                $mail->Password   = 'AuburnFuckBama13!';                //SMTP password
+                $mail->Password   = '0';                                //SMTP password - deleted
                 $mail->SMTPSecure = 'STARTTLS';                         //Enable implicit TLS encryptionS
                 $mail->Port       = 587;                                //TCP port to connect to; use 587 if you have set `SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS                             //SMTP password
 

--- a/resources/php/generarPago.php
+++ b/resources/php/generarPago.php
@@ -181,7 +181,7 @@ require '../../dependencies/PHPMailer-master/src/SMTP.php';
     $mail->Host       = 'smtp.office365.com';               //Set the SMTP server to send through
     $mail->SMTPAuth   = true;                               //Enable SMTP authentication
     $mail->Username   = 'mamba_sneakers@outlook.com';       //SMTP username
-    $mail->Password   = 'AuburnFuckBama13!';                //SMTP password
+    $mail->Password   = '0';                                //SMTP password - deleted
     $mail->SMTPSecure = 'STARTTLS';                         //Enable implicit TLS encryptionS
     $mail->Port       = 587;                                //TCP port to connect to; use 587 if you have set `SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS                             //SMTP password
     $mail->setFrom('mamba_sneakers@outlook.com', 'Mamba Sneakers');

--- a/resources/php/suscription.php
+++ b/resources/php/suscription.php
@@ -70,7 +70,7 @@ require '../dependencies/PHPMailer-master/src/SMTP.php';
             $mail->Host       = 'smtp.office365.com';               //Set the SMTP server to send through
             $mail->SMTPAuth   = true;                               //Enable SMTP authentication
             $mail->Username   = 'mamba_sneakers@outlook.com';       //SMTP username
-            $mail->Password   = 'AuburnFuckBama13!';                //SMTP password
+            $mail->Password   = '0';                                //SMTP password - deleted
             $mail->SMTPSecure = 'STARTTLS';                         //Enable implicit TLS encryptionS
             $mail->Port       = 587;                                //TCP port to connect to; use 587 if you have set `SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS                             //SMTP password
 


### PR DESCRIPTION
Se eliminó la contraseña de email de empresa en las páginas:
contacto.php
generarPago.php
suscripción.php